### PR TITLE
Test up to WordPress 7.0 and release version 2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ You can find the plugin on https://wordpress.org/plugins/smntcs-deactivate-image
 
 ## Changelog
 
+### 2.1 (2026.08.14)
+
+-   Test up to WordPress 7.0
+
 ### 2.0 (2025.03.21)
 
 -   Test up to WordPress 6.8

--- a/README.txt
+++ b/README.txt
@@ -2,8 +2,8 @@
 
 Contributors:       nielslange
 Tags:               Image compression
-Stable tag:         2.0
-Tested up to:       6.8
+Stable tag:         2.1
+Tested up to:       7.0
 Requires PHP:       7.4
 Requires at least:  2.5
 License:            GPL v2 or later
@@ -25,6 +25,10 @@ Deactivate the WordPress default image compression which got introduced with [Wo
 By default, WordPress compress every uploaded image by 90%. In combination with other image optimisation tools, this can lead to pixelated images. This plugin deactivates the default image compression to avoid this issue.
 
 == Changelog ==
+
+= 2.1 (2026.08.14) =
+
+-   Test up to WordPress 7.0
 
 = 2.0 (2025.03.21) =
 

--- a/composer.json
+++ b/composer.json
@@ -20,9 +20,9 @@
 		"humanmade/psalm-plugin-wordpress": "3.1.2",
 		"overtrue/phplint": "9.5.6",
 		"phpcompatibility/phpcompatibility-wp": "2.1.6",
-		"squizlabs/php_codesniffer": "3.12.1",
+		"squizlabs/php_codesniffer": "3.13.6",
 		"vimeo/psalm": "6.10.0",
-		"wp-coding-standards/wpcs": "3.1.0"
+		"wp-coding-standards/wpcs": "3.4.1"
 	},
 	"scripts": {
 		"phpcbf": "phpcbf --standard=phpcs.dist.xml .",

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
 		"overtrue/phplint": "9.5.6",
 		"phpcompatibility/phpcompatibility-wp": "2.1.6",
 		"squizlabs/php_codesniffer": "3.13.6",
-		"vimeo/psalm": "6.10.0",
+		"vimeo/psalm": "5.26.1",
 		"wp-coding-standards/wpcs": "3.4.1"
 	},
 	"scripts": {

--- a/smntcs-deactivate-image-compression.php
+++ b/smntcs-deactivate-image-compression.php
@@ -6,7 +6,7 @@
  * Author:                Niels Lange
  * Author URI:            https://nielslange.de
  * Text Domain:           smntcs-deactivate-image-compression
- * Version:               2.0
+ * Version:               2.1
  * Requires PHP:          7.4
  * Requires at least:     2.5
  * License:               GPL v2 or later


### PR DESCRIPTION
- Bump version 2.0 → 2.1 in plugin header and `Stable tag`
- Bump `Tested up to` to 7.0
- Add 2.1 changelog entry to README.txt and README.md
- Bump pinned dev tools blocked by Composer security advisories (CI would fail otherwise): `squizlabs/php_codesniffer` 3.12.1 → 3.13.6 (CVE-2026-67434), `wp-coding-standards/wpcs` 3.1.0 → 3.4.1 (PKSA-mh9b-91zm-m1gy)
- Pin `vimeo/psalm` 6.10.0 → 5.26.1: psalm 6.x requires PHP ~8.3.16+, but the ubuntu-latest runner's distro PHP is 8.3.6, which broke `composer install` for every CI job (pre-existing on trunk). 5.26.1 matches the pin used across the other SMNTCS plugins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)